### PR TITLE
getResultsDataFrame output returns tibble

### DIFF
--- a/R/R6-classes.R
+++ b/R/R6-classes.R
@@ -1,5 +1,5 @@
 library(hash)
-
+library(readr)
 
 # ======================
 #    ADAPTER CODE
@@ -489,7 +489,7 @@ PicSureHpdsQuery <- R6::R6Class("PicSureHpdsQuery",
                                     self$performance['tmr_query'] <- Sys.time()
                                     httpResults = self$INTERNAL_API_OBJ$synchQuery(self$resourceUUID, queryJSON)
                                     self$performance['tmr_recv'] <- Sys.time()
-                                    ret = read.csv(text=httpResults)
+                                    ret = read_csv(file=httpResults)
                                     self$performance['tmr_proc'] <- Sys.time()
                                     self$performance['running'] <- FALSE
                                     return(ret)
@@ -508,7 +508,7 @@ PicSureHpdsQuery <- R6::R6Class("PicSureHpdsQuery",
                                     self$performance['tmr_query'] <- Sys.time()
                                     httpResults = self$INTERNAL_API_OBJ$synchQuery(self$resourceUUID, queryJSON)
                                     self$performance['tmr_recv'] <- Sys.time()
-                                    ret = read.csv(text=httpResults)
+                                    ret = readr::read_csv(file=httpResults)
                                     self$performance['tmr_proc'] <- Sys.time()
                                     self$performance['running'] <- FALSE
                                     return(ret)


### PR DESCRIPTION
Modifying getResultsDataFrame output in order to make it returns a "tibble" data.frame, instead of a base R data.frame: the main purpose is to avoid turning backslashes and blank spaces into dots in the column names when reading the csv file