### PR TITLE
Update R Documentation for the find.in.dictionary and query.run 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Library that is used to connect to access
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.2
 Depends: R (>= 3.1.0)
 Imports:
   R6,

--- a/R/hpds.R
+++ b/R/hpds.R
@@ -43,7 +43,7 @@ get.resource <- function(connection, resourceUUID, verbose=FALSE) {
 #' Search the data dictionary of a PIC-SURE resource.
 #'
 #' @param resource A PIC-SURE resource object.
-#' @param term A string to search for in the resource's data dictionary.
+#' @param term A string to search for in the resource's data dictionary. By default, if no term is provided, the whole dictionary will be returned.
 #' @param verbose Flag to display additional runtime information.
 #' @return An object representing the search results.
 #' @examples
@@ -187,7 +187,14 @@ new.query <- function(resource, verbose=FALSE) {
 #' Run a query instance using any restrictions that have been added to it.
 #'
 #' @param query A query instance object.
-#' @param result.type A string specifying what type of results to return. Possible values: "count", "results", "dataframe", "crosscount", "variantsApproximateCount" and "variantsDataFrame".
+#' @param result.type A string specifying what type of results to return. Possible values: "count", "dataframe", "variantsApproximateCount" and "variantsDataFrame".
+#' @details Description of result.type values
+##' \itemize{
+##'  \item{"count": }{Single count indicating the number of matching records}
+##'  \item{"dataframe": }{DataFrame containing the matching records}
+##'  \item{"variantsApproximateCount": }{Single estimated count of the number of matching variants}
+##'  \item{"variantsDataFrame": }{DataFrame of the matching variants}
+##' }
 #' @param verbose Flag to display additional runtime information.
 #' @examples
 #'

--- a/hpds.Rproj
+++ b/hpds.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace,vignette

--- a/man/BypassAdapter.Rd
+++ b/man/BypassAdapter.Rd
@@ -4,14 +4,15 @@
 \name{BypassAdapter}
 \alias{BypassAdapter}
 \title{R6 class that selects a HPDS-hosted resources directly without the use of the PIC-SURE Connection library.}
-\format{\code{PicSureHpdsBypassAdapter} object.}
-\usage{
-BypassAdapter
+\format{
+\code{PicSureHpdsBypassAdapter} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource without using a PIC-SURE network.
 }
 \description{
+R6 class that selects a HPDS-hosted resources directly without the use of the PIC-SURE Connection library.
+
 R6 class that selects a HPDS-hosted resources directly without the use of the PIC-SURE Connection library.
 }
 \section{Methods}{
@@ -25,3 +26,47 @@ R6 class that selects a HPDS-hosted resources directly without the use of the PI
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{BypassAdapter$new()}}
+\item \href{#method-useResource}{\code{BypassAdapter$useResource()}}
+\item \href{#method-clone}{\code{BypassAdapter$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{BypassAdapter$new(url_arg, token_arg = FALSE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-useResource"></a>}}
+\if{latex}{\out{\hypertarget{method-useResource}{}}}
+\subsection{Method \code{useResource()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{BypassAdapter$useResource(resource_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{BypassAdapter$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/HpdsAttribList.Rd
+++ b/man/HpdsAttribList.Rd
@@ -4,14 +4,15 @@
 \name{HpdsAttribList}
 \alias{HpdsAttribList}
 \title{R6 class used as base class for all query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{HpdsAttribList}} object.}
-\usage{
-HpdsAttribList
+\format{
+\code{\link{HpdsAttribList}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
+R6 class used as base class for all query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
+
 R6 class used as base class for all query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -28,3 +29,112 @@ R6 class used as base class for all query parameter lists - DO NOT CREATE THIS O
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{HpdsAttribList$new()}}
+\item \href{#method-add}{\code{HpdsAttribList$add()}}
+\item \href{#method-delete}{\code{HpdsAttribList$delete()}}
+\item \href{#method-show}{\code{HpdsAttribList$show()}}
+\item \href{#method-clear}{\code{HpdsAttribList$clear()}}
+\item \href{#method-getQueryValues}{\code{HpdsAttribList$getQueryValues()}}
+\item \href{#method-normalize_VariantSpec}{\code{HpdsAttribList$normalize_VariantSpec()}}
+\item \href{#method-is_VariantSpec}{\code{HpdsAttribList$is_VariantSpec()}}
+\item \href{#method-clone}{\code{HpdsAttribList$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$new(
+  inst_list = FALSE,
+  help_text = "",
+  allow_variants = TRUE,
+  dictionary_obj = FALSE
+)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-add"></a>}}
+\if{latex}{\out{\hypertarget{method-add}{}}}
+\subsection{Method \code{add()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$add(keys = FALSE, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-delete"></a>}}
+\if{latex}{\out{\hypertarget{method-delete}{}}}
+\subsection{Method \code{delete()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$delete(keys, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-show"></a>}}
+\if{latex}{\out{\hypertarget{method-show}{}}}
+\subsection{Method \code{show()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$show()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clear"></a>}}
+\if{latex}{\out{\hypertarget{method-clear}{}}}
+\subsection{Method \code{clear()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$clear()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getQueryValues"></a>}}
+\if{latex}{\out{\hypertarget{method-getQueryValues}{}}}
+\subsection{Method \code{getQueryValues()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$getQueryValues()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-normalize_VariantSpec"></a>}}
+\if{latex}{\out{\hypertarget{method-normalize_VariantSpec}{}}}
+\subsection{Method \code{normalize_VariantSpec()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$normalize_VariantSpec(teststr)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-is_VariantSpec"></a>}}
+\if{latex}{\out{\hypertarget{method-is_VariantSpec}{}}}
+\subsection{Method \code{is_VariantSpec()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$is_VariantSpec(teststr)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribList$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/HpdsAttribListKeyValues.Rd
+++ b/man/HpdsAttribListKeyValues.Rd
@@ -4,14 +4,15 @@
 \name{HpdsAttribListKeyValues}
 \alias{HpdsAttribListKeyValues}
 \title{R6 class used to store/manipulate Key+Value query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{HpdsAttribListKeyValues}} object.}
-\usage{
-HpdsAttribListKeyValues
+\format{
+\code{\link{HpdsAttribListKeyValues}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
+R6 class used to store/manipulate Key+Value query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
+
 R6 class used to store/manipulate Key+Value query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -28,3 +29,99 @@ R6 class used to store/manipulate Key+Value query parameter lists - DO NOT CREAT
 }
 
 \keyword{data}
+\section{Super class}{
+\code{\link[hpds:HpdsAttribList]{hpds::HpdsAttribList}} -> \code{HpdsAttribListKeyValues}
+}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{HpdsAttribListKeyValues$new()}}
+\item \href{#method-add}{\code{HpdsAttribListKeyValues$add()}}
+\item \href{#method-delete}{\code{HpdsAttribListKeyValues$delete()}}
+\item \href{#method-load}{\code{HpdsAttribListKeyValues$load()}}
+\item \href{#method-getQueryValues}{\code{HpdsAttribListKeyValues$getQueryValues()}}
+\item \href{#method-clone}{\code{HpdsAttribListKeyValues$clone()}}
+}
+}
+\if{html}{
+\out{<details open ><summary>Inherited methods</summary>}
+\itemize{
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="clear">}\href{../../hpds/html/HpdsAttribList.html#method-clear}{\code{hpds::HpdsAttribList$clear()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="is_VariantSpec">}\href{../../hpds/html/HpdsAttribList.html#method-is_VariantSpec}{\code{hpds::HpdsAttribList$is_VariantSpec()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="normalize_VariantSpec">}\href{../../hpds/html/HpdsAttribList.html#method-normalize_VariantSpec}{\code{hpds::HpdsAttribList$normalize_VariantSpec()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="show">}\href{../../hpds/html/HpdsAttribList.html#method-show}{\code{hpds::HpdsAttribList$show()}}\out{</span>}
+}
+\out{</details>}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$new(
+  inst_list = FALSE,
+  help_text = "",
+  allow_variants = TRUE,
+  dictionary_obj = FALSE
+)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-add"></a>}}
+\if{latex}{\out{\hypertarget{method-add}{}}}
+\subsection{Method \code{add()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$add(key = FALSE, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-delete"></a>}}
+\if{latex}{\out{\hypertarget{method-delete}{}}}
+\subsection{Method \code{delete()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$delete(key = FALSE, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-load"></a>}}
+\if{latex}{\out{\hypertarget{method-load}{}}}
+\subsection{Method \code{load()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$load(
+  numericFilters = list(),
+  categoryFilters = list(),
+  variantInfoFilters = list()
+)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getQueryValues"></a>}}
+\if{latex}{\out{\hypertarget{method-getQueryValues}{}}}
+\subsection{Method \code{getQueryValues()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$getQueryValues()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeyValues$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/HpdsAttribListKeys.Rd
+++ b/man/HpdsAttribListKeys.Rd
@@ -4,14 +4,15 @@
 \name{HpdsAttribListKeys}
 \alias{HpdsAttribListKeys}
 \title{R6 class used to store/manipulate key-only query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{HpdsAttribListKeys}} object.}
-\usage{
-HpdsAttribListKeys
+\format{
+\code{\link{HpdsAttribListKeys}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
+R6 class used to store/manipulate key-only query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
+
 R6 class used to store/manipulate key-only query parameter lists - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -28,3 +29,95 @@ R6 class used to store/manipulate key-only query parameter lists - DO NOT CREATE
 }
 
 \keyword{data}
+\section{Super class}{
+\code{\link[hpds:HpdsAttribList]{hpds::HpdsAttribList}} -> \code{HpdsAttribListKeys}
+}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{HpdsAttribListKeys$new()}}
+\item \href{#method-add}{\code{HpdsAttribListKeys$add()}}
+\item \href{#method-delete}{\code{HpdsAttribListKeys$delete()}}
+\item \href{#method-getQueryValues}{\code{HpdsAttribListKeys$getQueryValues()}}
+\item \href{#method-load}{\code{HpdsAttribListKeys$load()}}
+\item \href{#method-clone}{\code{HpdsAttribListKeys$clone()}}
+}
+}
+\if{html}{
+\out{<details open ><summary>Inherited methods</summary>}
+\itemize{
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="clear">}\href{../../hpds/html/HpdsAttribList.html#method-clear}{\code{hpds::HpdsAttribList$clear()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="is_VariantSpec">}\href{../../hpds/html/HpdsAttribList.html#method-is_VariantSpec}{\code{hpds::HpdsAttribList$is_VariantSpec()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="normalize_VariantSpec">}\href{../../hpds/html/HpdsAttribList.html#method-normalize_VariantSpec}{\code{hpds::HpdsAttribList$normalize_VariantSpec()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="hpds" data-topic="HpdsAttribList" data-id="show">}\href{../../hpds/html/HpdsAttribList.html#method-show}{\code{hpds::HpdsAttribList$show()}}\out{</span>}
+}
+\out{</details>}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$new(
+  inst_list = FALSE,
+  help_text = "",
+  allow_variants = TRUE,
+  dictionary_obj = FALSE
+)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-add"></a>}}
+\if{latex}{\out{\hypertarget{method-add}{}}}
+\subsection{Method \code{add()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$add(key = FALSE, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-delete"></a>}}
+\if{latex}{\out{\hypertarget{method-delete}{}}}
+\subsection{Method \code{delete()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$delete(key = FALSE, ...)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getQueryValues"></a>}}
+\if{latex}{\out{\hypertarget{method-getQueryValues}{}}}
+\subsection{Method \code{getQueryValues()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$getQueryValues()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-load"></a>}}
+\if{latex}{\out{\hypertarget{method-load}{}}}
+\subsection{Method \code{load()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$load(keys)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HpdsAttribListKeys$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsBypassConnection.Rd
+++ b/man/PicSureHpdsBypassConnection.Rd
@@ -4,14 +4,15 @@
 \name{PicSureHpdsBypassConnection}
 \alias{PicSureHpdsBypassConnection}
 \title{R6 class that is a code-shim used by the PicSureBypassAdapter - DO NOT USE THIS OBJECT DIRECTLY!}
-\format{\code{\link{PicSureHpdsBypassConnection}} object.}
-\usage{
-PicSureHpdsBypassConnection
+\format{
+\code{\link{PicSureHpdsBypassConnection}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used by the \code{PicSureBypassAdapter} to access a HPDS-hosted resource without using a PIC-SURE network.
 }
 \description{
+R6 class that is a code-shim used by the PicSureBypassAdapter - DO NOT USE THIS OBJECT DIRECTLY!
+
 R6 class that is a code-shim used by the PicSureBypassAdapter - DO NOT USE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -21,3 +22,67 @@ R6 class that is a code-shim used by the PicSureBypassAdapter - DO NOT USE THIS 
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsBypassConnection$new()}}
+\item \href{#method-list}{\code{PicSureHpdsBypassConnection$list()}}
+\item \href{#method-INTERNAL_api_obj}{\code{PicSureHpdsBypassConnection$INTERNAL_api_obj()}}
+\item \href{#method-getResources}{\code{PicSureHpdsBypassConnection$getResources()}}
+\item \href{#method-clone}{\code{PicSureHpdsBypassConnection$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnection$new(url_arg, token_arg)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-list"></a>}}
+\if{latex}{\out{\hypertarget{method-list}{}}}
+\subsection{Method \code{list()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnection$list()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-INTERNAL_api_obj"></a>}}
+\if{latex}{\out{\hypertarget{method-INTERNAL_api_obj}{}}}
+\subsection{Method \code{INTERNAL_api_obj()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnection$INTERNAL_api_obj()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getResources"></a>}}
+\if{latex}{\out{\hypertarget{method-getResources}{}}}
+\subsection{Method \code{getResources()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnection$getResources()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnection$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsBypassConnectionAPI.Rd
+++ b/man/PicSureHpdsBypassConnectionAPI.Rd
@@ -4,14 +4,15 @@
 \name{PicSureHpdsBypassConnectionAPI}
 \alias{PicSureHpdsBypassConnectionAPI}
 \title{R6 class that is a code-shim used by the PicSureBypassConnection - DO NOT USE THIS OBJECT DIRECTLY!}
-\format{\code{\link{PicSureHpdsBypassConnectionAPI}} object.}
-\usage{
-PicSureHpdsBypassConnectionAPI
+\format{
+\code{\link{PicSureHpdsBypassConnectionAPI}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used by the \code{PicSureHpdsBypassConnection} to access a HPDS-hosted resource without using a PIC-SURE network.
 }
 \description{
+R6 class that is a code-shim used by the PicSureBypassConnection - DO NOT USE THIS OBJECT DIRECTLY!
+
 R6 class that is a code-shim used by the PicSureBypassConnection - DO NOT USE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -21,3 +22,97 @@ R6 class that is a code-shim used by the PicSureBypassConnection - DO NOT USE TH
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsBypassConnectionAPI$new()}}
+\item \href{#method-info}{\code{PicSureHpdsBypassConnectionAPI$info()}}
+\item \href{#method-search}{\code{PicSureHpdsBypassConnectionAPI$search()}}
+\item \href{#method-asynchQuery}{\code{PicSureHpdsBypassConnectionAPI$asynchQuery()}}
+\item \href{#method-synchQuery}{\code{PicSureHpdsBypassConnectionAPI$synchQuery()}}
+\item \href{#method-queryStatus}{\code{PicSureHpdsBypassConnectionAPI$queryStatus()}}
+\item \href{#method-queryResult}{\code{PicSureHpdsBypassConnectionAPI$queryResult()}}
+\item \href{#method-clone}{\code{PicSureHpdsBypassConnectionAPI$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$new(arg_url, arg_token)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-info"></a>}}
+\if{latex}{\out{\hypertarget{method-info}{}}}
+\subsection{Method \code{info()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$info(resource_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-search"></a>}}
+\if{latex}{\out{\hypertarget{method-search}{}}}
+\subsection{Method \code{search()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$search(resource_uuid, query = FALSE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-asynchQuery"></a>}}
+\if{latex}{\out{\hypertarget{method-asynchQuery}{}}}
+\subsection{Method \code{asynchQuery()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$asynchQuery(resource_uuid, query)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-synchQuery"></a>}}
+\if{latex}{\out{\hypertarget{method-synchQuery}{}}}
+\subsection{Method \code{synchQuery()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$synchQuery(resource_uuid, query)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-queryStatus"></a>}}
+\if{latex}{\out{\hypertarget{method-queryStatus}{}}}
+\subsection{Method \code{queryStatus()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$queryStatus(resource_uuid, query_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-queryResult"></a>}}
+\if{latex}{\out{\hypertarget{method-queryResult}{}}}
+\subsection{Method \code{queryResult()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$queryResult(resource_uuid, query_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsBypassConnectionAPI$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsDictionary.Rd
+++ b/man/PicSureHpdsDictionary.Rd
@@ -4,14 +4,15 @@
 \name{PicSureHpdsDictionary}
 \alias{PicSureHpdsDictionary}
 \title{R6 class that runs searches against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{PicSureHpdsDictionary}} object.}
-\usage{
-PicSureHpdsDictionary
+\format{
+\code{\link{PicSureHpdsDictionary}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
+R6 class that runs searches against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!
+
 R6 class that runs searches against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -24,3 +25,67 @@ R6 class that runs searches against a HPDS resource's data dictionary - DO NOT C
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsDictionary$new()}}
+\item \href{#method-getKeyInfo}{\code{PicSureHpdsDictionary$getKeyInfo()}}
+\item \href{#method-getDataframe}{\code{PicSureHpdsDictionary$getDataframe()}}
+\item \href{#method-find}{\code{PicSureHpdsDictionary$find()}}
+\item \href{#method-clone}{\code{PicSureHpdsDictionary$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionary$new(refHpdsResourceConnection)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getKeyInfo"></a>}}
+\if{latex}{\out{\hypertarget{method-getKeyInfo}{}}}
+\subsection{Method \code{getKeyInfo()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionary$getKeyInfo(key)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getDataframe"></a>}}
+\if{latex}{\out{\hypertarget{method-getDataframe}{}}}
+\subsection{Method \code{getDataframe()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionary$getDataframe(term = "", useQueryScopes = TRUE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-find"></a>}}
+\if{latex}{\out{\hypertarget{method-find}{}}}
+\subsection{Method \code{find()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionary$find(term = "", showAll = FALSE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionary$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsDictionaryResult.Rd
+++ b/man/PicSureHpdsDictionaryResult.Rd
@@ -4,14 +4,83 @@
 \name{PicSureHpdsDictionaryResult}
 \alias{PicSureHpdsDictionaryResult}
 \title{R6 class contain the results of a search against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{PicSureHpdsDictionaryResult}} object.}
-\usage{
-PicSureHpdsDictionaryResult
+\format{
+\code{\link{PicSureHpdsDictionaryResult}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
 R6 class contain the results of a search against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!
+
+R6 class contain the results of a search against a HPDS resource's data dictionary - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
+\section{}{
+NA
+}
+
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsDictionaryResult$new()}}
+\item \href{#method-count}{\code{PicSureHpdsDictionaryResult$count()}}
+\item \href{#method-keys}{\code{PicSureHpdsDictionaryResult$keys()}}
+\item \href{#method-entries}{\code{PicSureHpdsDictionaryResult$entries()}}
+\item \href{#method-clone}{\code{PicSureHpdsDictionaryResult$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionaryResult$new(results, filter.list = FALSE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-count"></a>}}
+\if{latex}{\out{\hypertarget{method-count}{}}}
+\subsection{Method \code{count()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionaryResult$count()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-keys"></a>}}
+\if{latex}{\out{\hypertarget{method-keys}{}}}
+\subsection{Method \code{keys()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionaryResult$keys()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-entries"></a>}}
+\if{latex}{\out{\hypertarget{method-entries}{}}}
+\subsection{Method \code{entries()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionaryResult$entries()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsDictionaryResult$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsQuery.Rd
+++ b/man/PicSureHpdsQuery.Rd
@@ -4,14 +4,15 @@
 \name{PicSureHpdsQuery}
 \alias{PicSureHpdsQuery}
 \title{R6 class used to build a multi-use query to search against a HPDS resource's data - DO NOT CREATE THIS OBJECT DIRECTLY!}
-\format{\code{\link{PicSureHpdsQuery}} object.}
-\usage{
-PicSureHpdsQuery
+\format{
+\code{\link{PicSureHpdsQuery}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access a HPDS-hosted resource's data dictionary.
 }
 \description{
+R6 class used to build a multi-use query to search against a HPDS resource's data - DO NOT CREATE THIS OBJECT DIRECTLY!
+
 R6 class used to build a multi-use query to search against a HPDS resource's data - DO NOT CREATE THIS OBJECT DIRECTLY!
 }
 \section{Methods}{
@@ -35,3 +36,197 @@ R6 class used to build a multi-use query to search against a HPDS resource's dat
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsQuery$new()}}
+\item \href{#method-show}{\code{PicSureHpdsQuery$show()}}
+\item \href{#method-select}{\code{PicSureHpdsQuery$select()}}
+\item \href{#method-crosscounts}{\code{PicSureHpdsQuery$crosscounts()}}
+\item \href{#method-require}{\code{PicSureHpdsQuery$require()}}
+\item \href{#method-anyof}{\code{PicSureHpdsQuery$anyof()}}
+\item \href{#method-filter}{\code{PicSureHpdsQuery$filter()}}
+\item \href{#method-getCount}{\code{PicSureHpdsQuery$getCount()}}
+\item \href{#method-getResults}{\code{PicSureHpdsQuery$getResults()}}
+\item \href{#method-getResultsDataFrame}{\code{PicSureHpdsQuery$getResultsDataFrame()}}
+\item \href{#method-getVariantsApproximateCount}{\code{PicSureHpdsQuery$getVariantsApproximateCount()}}
+\item \href{#method-getVariantsDataFrame}{\code{PicSureHpdsQuery$getVariantsDataFrame()}}
+\item \href{#method-getRunDetails}{\code{PicSureHpdsQuery$getRunDetails()}}
+\item \href{#method-save}{\code{PicSureHpdsQuery$save()}}
+\item \href{#method-load}{\code{PicSureHpdsQuery$load()}}
+\item \href{#method-loadInternal}{\code{PicSureHpdsQuery$loadInternal()}}
+\item \href{#method-buildQuery}{\code{PicSureHpdsQuery$buildQuery()}}
+\item \href{#method-clone}{\code{PicSureHpdsQuery$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$new(connection)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-show"></a>}}
+\if{latex}{\out{\hypertarget{method-show}{}}}
+\subsection{Method \code{show()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$show()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-select"></a>}}
+\if{latex}{\out{\hypertarget{method-select}{}}}
+\subsection{Method \code{select()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$select()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-crosscounts"></a>}}
+\if{latex}{\out{\hypertarget{method-crosscounts}{}}}
+\subsection{Method \code{crosscounts()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$crosscounts()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-require"></a>}}
+\if{latex}{\out{\hypertarget{method-require}{}}}
+\subsection{Method \code{require()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$require()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-anyof"></a>}}
+\if{latex}{\out{\hypertarget{method-anyof}{}}}
+\subsection{Method \code{anyof()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$anyof()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-filter"></a>}}
+\if{latex}{\out{\hypertarget{method-filter}{}}}
+\subsection{Method \code{filter()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$filter()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getCount"></a>}}
+\if{latex}{\out{\hypertarget{method-getCount}{}}}
+\subsection{Method \code{getCount()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getCount(asAsync = FALSE, timeout = 30)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getResults"></a>}}
+\if{latex}{\out{\hypertarget{method-getResults}{}}}
+\subsection{Method \code{getResults()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getResults(asAsync = FALSE, timeout = 30)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getResultsDataFrame"></a>}}
+\if{latex}{\out{\hypertarget{method-getResultsDataFrame}{}}}
+\subsection{Method \code{getResultsDataFrame()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getResultsDataFrame(asAsync = FALSE, timeout = 30)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getVariantsApproximateCount"></a>}}
+\if{latex}{\out{\hypertarget{method-getVariantsApproximateCount}{}}}
+\subsection{Method \code{getVariantsApproximateCount()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getVariantsApproximateCount(asAsync = FALSE, timeout = 30)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getVariantsDataFrame"></a>}}
+\if{latex}{\out{\hypertarget{method-getVariantsDataFrame}{}}}
+\subsection{Method \code{getVariantsDataFrame()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getVariantsDataFrame(asAsync = FALSE, timeout = 30)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getRunDetails"></a>}}
+\if{latex}{\out{\hypertarget{method-getRunDetails}{}}}
+\subsection{Method \code{getRunDetails()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$getRunDetails()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-save"></a>}}
+\if{latex}{\out{\hypertarget{method-save}{}}}
+\subsection{Method \code{save()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$save(resultType = "COUNT")}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-load"></a>}}
+\if{latex}{\out{\hypertarget{method-load}{}}}
+\subsection{Method \code{load()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$load(queryStr = "{}", merge = TRUE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-loadInternal"></a>}}
+\if{latex}{\out{\hypertarget{method-loadInternal}{}}}
+\subsection{Method \code{loadInternal()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$loadInternal(queryObj, merge = TRUE)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-buildQuery"></a>}}
+\if{latex}{\out{\hypertarget{method-buildQuery}{}}}
+\subsection{Method \code{buildQuery()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$buildQuery(resultType = "COUNT")}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsQuery$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/PicSureHpdsResourceConnection.Rd
+++ b/man/PicSureHpdsResourceConnection.Rd
@@ -4,14 +4,15 @@
 \name{PicSureHpdsResourceConnection}
 \alias{PicSureHpdsResourceConnection}
 \title{R6 class that allows access to the data dictionary and query services of a selected HPDS-hosted resources on a PIC-SURE network.}
-\format{\code{\link{PicSureHpdsResourceConnection}} object.}
-\usage{
-PicSureHpdsResourceConnection
+\format{
+\code{\link{PicSureHpdsResourceConnection}} object.
 }
 \value{
 Object of \code{\link{R6Class}} used to access the dictionary and query services via the objects it returns.
 }
 \description{
+R6 class that allows access to the data dictionary and query services of a selected HPDS-hosted resources on a PIC-SURE network.
+
 R6 class that allows access to the data dictionary and query services of a selected HPDS-hosted resources on a PIC-SURE network.
 }
 \section{Methods}{
@@ -25,3 +26,87 @@ R6 class that allows access to the data dictionary and query services of a selec
 }
 
 \keyword{data}
+\section{Methods}{
+\subsection{Public methods}{
+\itemize{
+\item \href{#method-new}{\code{PicSureHpdsResourceConnection$new()}}
+\item \href{#method-version}{\code{PicSureHpdsResourceConnection$version()}}
+\item \href{#method-dictionary}{\code{PicSureHpdsResourceConnection$dictionary()}}
+\item \href{#method-query}{\code{PicSureHpdsResourceConnection$query()}}
+\item \href{#method-retrieveQueryResults}{\code{PicSureHpdsResourceConnection$retrieveQueryResults()}}
+\item \href{#method-getQueryByUUID}{\code{PicSureHpdsResourceConnection$getQueryByUUID()}}
+\item \href{#method-clone}{\code{PicSureHpdsResourceConnection$clone()}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-new"></a>}}
+\if{latex}{\out{\hypertarget{method-new}{}}}
+\subsection{Method \code{new()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$new(connection, resource_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-version"></a>}}
+\if{latex}{\out{\hypertarget{method-version}{}}}
+\subsection{Method \code{version()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$version()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-dictionary"></a>}}
+\if{latex}{\out{\hypertarget{method-dictionary}{}}}
+\subsection{Method \code{dictionary()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$dictionary()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-query"></a>}}
+\if{latex}{\out{\hypertarget{method-query}{}}}
+\subsection{Method \code{query()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$query(loadQuery = NA)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-retrieveQueryResults"></a>}}
+\if{latex}{\out{\hypertarget{method-retrieveQueryResults}{}}}
+\subsection{Method \code{retrieveQueryResults()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$retrieveQueryResults(query_uuid = NA)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-getQueryByUUID"></a>}}
+\if{latex}{\out{\hypertarget{method-getQueryByUUID}{}}}
+\subsection{Method \code{getQueryByUUID()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$getQueryByUUID(query_uuid)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\if{latex}{\out{\hypertarget{method-clone}{}}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PicSureHpdsResourceConnection$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
+}
+\if{html}{\out{</div>}}
+}
+}
+}

--- a/man/find.in.dictionary.Rd
+++ b/man/find.in.dictionary.Rd
@@ -9,7 +9,7 @@ find.in.dictionary(resource, term = "", verbose = FALSE)
 \arguments{
 \item{resource}{A PIC-SURE resource object.}
 
-\item{term}{A string to search for in the resource's data dictionary.}
+\item{term}{A string to search for in the resource's data dictionary. By default, if no term is provided, the whole dictionary will be returned.}
 
 \item{verbose}{Flag to display additional runtime information.}
 }

--- a/man/get.resource.Rd
+++ b/man/get.resource.Rd
@@ -14,7 +14,7 @@ get.resource(connection, resourceUUID, verbose = FALSE)
 \item{verbose}{Flag to display additional runtime information.}
 }
 \value{
-An object which provides access to the requested Resource.
+An object which provides access to the requested Resource. test
 }
 \description{
 Get a new reference to a HPDS-based PIC-SURE resource.

--- a/man/hpds.Rd
+++ b/man/hpds.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{hpds}
 \alias{hpds}
-\alias{hpds-package}
 \title{hpds: An Adapter Library for HPDS Services on PIC-SURE Networks.}
 \description{
 This package is used to interact with HPDS Services and data hosted

--- a/man/query.anyof.add.Rd
+++ b/man/query.anyof.add.Rd
@@ -21,6 +21,6 @@ Add an "AnyOf" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.anyof.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.anyof.add(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.anyof.delete.Rd
+++ b/man/query.anyof.delete.Rd
@@ -21,8 +21,8 @@ Delete an "AnyOf" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.anyof.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.anyof.add(query=myquery, keys="\\demographics\\SEX\\")
 ## ...opps, added wrong term, lets delete it...
-# hpds::query.anyof.delete(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.anyof.delete(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.crosscounts.add.Rd
+++ b/man/query.crosscounts.add.Rd
@@ -21,6 +21,6 @@ Add a "cross-counts" restriction to a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.crosscounts.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.crosscounts.add(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.crosscounts.delete.Rd
+++ b/man/query.crosscounts.delete.Rd
@@ -21,8 +21,8 @@ Delete a "cross-counts" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.crosscounts.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.crosscounts.add(query=myquery, keys="\\demographics\\SEX\\")
 ## ...opps, added wrong term, lets delete it...
-# hpds::query.crosscounts.delete(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.crosscounts.delete(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.filter.add.Rd
+++ b/man/query.filter.add.Rd
@@ -23,6 +23,6 @@ Add a "Filter" restriction to a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.select.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\", values="Male")
+# hpds::query.select.add(query=myquery, keys="\\demographics\\SEX\\", values="Male")
 
 }

--- a/man/query.filter.delete.Rd
+++ b/man/query.filter.delete.Rd
@@ -21,8 +21,8 @@ Delete a "Filter" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.filter.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\", values="Male")
+# hpds::query.filter.add(query=myquery, keys="\\demographics\\SEX\\", values="Male")
 ## ...opps, added wrong term, lets delete it...
-# hpds::query.filter.delete(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.filter.delete(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.require.add.Rd
+++ b/man/query.require.add.Rd
@@ -21,6 +21,6 @@ Add a "require" restriction to a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.require.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.require.add(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.require.delete.Rd
+++ b/man/query.require.delete.Rd
@@ -21,8 +21,8 @@ Delete a "require" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.require.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.require.add(query=myquery, keys="\\demographics\\SEX\\")
 ## ...opps, added wrong term, lets delete it...
-# hpds::query.require.delete(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.require.delete(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.run.Rd
+++ b/man/query.run.Rd
@@ -9,12 +9,21 @@ query.run(query, result.type = "dataframe", verbose = FALSE)
 \arguments{
 \item{query}{A query instance object.}
 
-\item{result.type}{A string specifying what type of results to return. Possible values: "count", "results", "dataframe", "crosscount", "variantsApproximateCount" and "variantsDataFrame".}
+\item{result.type}{A string specifying what type of results to return. Possible values: "count", "dataframe", "variantsApproximateCount" and "variantsDataFrame".}
 
 \item{verbose}{Flag to display additional runtime information.}
 }
 \description{
 Run a query instance using any restrictions that have been added to it.
+}
+\details{
+Description of result.type values
+\itemize{
+ \item{"count": }{Single count indicating the number of matching records}
+ \item{"dataframe": }{DataFrame containing the matching records}
+ \item{"variantsApproximateCount": }{Single estimated count of the number of matching variants}
+ \item{"variantsDataFrame": }{DataFrame of the matching variants}
+}
 }
 \examples{
 

--- a/man/query.select.add.Rd
+++ b/man/query.select.add.Rd
@@ -21,6 +21,6 @@ Add a "select" restriction to a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.select.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.select.add(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.select.delete.Rd
+++ b/man/query.select.delete.Rd
@@ -21,8 +21,8 @@ Delete a "select" restriction from a query instance.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.select.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.select.add(query=myquery, keys="\\demographics\\SEX\\")
 ## ...opps, added wrong term, lets delete it...
-# hpds::query.select.delete(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
+# hpds::query.select.delete(query=myquery, keys="\\demographics\\SEX\\")
 
 }

--- a/man/query.show.Rd
+++ b/man/query.show.Rd
@@ -19,10 +19,10 @@ Prints to screen the contents of a query instance's restriction parameters.
 # myconn <- picsure::connect(url="http://your.server/PIC-SURE/", token="your-security-token")
 # myres <- hpds::get.resource(connection=myconn, resourceUUID="YOUR-UUID-0000")
 # myquery <- hpds::new.query(resource=myres)
-# hpds::query.select.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\")
-# hpds::query.select.add(query=myquery, keys="\\\\demographics\\\\AGE\\\\")
-# hpds::query.filter.add(query=myquery, keys="\\\\demographics\\\\SEX\\\\", values="Female")
-# hpds::query.filter.add(query=myquery, keys="\\\\demographics\\\\AGE\\\\", min="10", max="65")
+# hpds::query.select.add(query=myquery, keys="\\demographics\\SEX\\")
+# hpds::query.select.add(query=myquery, keys="\\demographics\\AGE\\")
+# hpds::query.filter.add(query=myquery, keys="\\demographics\\SEX\\", values="Female")
+# hpds::query.filter.add(query=myquery, keys="\\demographics\\AGE\\", min="10", max="65")
 # hpds::query.show(query=myquery)
 
 }


### PR DESCRIPTION
The first change involves updating the help of the query.run function, as the accepted arguments have changed (for example, crosscounts is not supported in R and the variant options are not currently shown). Additionally, it would be helpful to provide a brief explanation of each possible value, as we do in the python documentation for the equivalent method.

The second change involves updating the help of the find.in.dictionary function, to specify how a user could return the complete dictionary for their resource. This distinction is noted in the current python documentation for the equivalent method but not in the R documentation.