### PR TITLE
Remove gsub as it is no longer necessary

### DIFF
--- a/R/picsure.R
+++ b/R/picsure.R
@@ -152,7 +152,7 @@ postJSON <- function(session, path, body, responseDeserializer = deserializeJSON
 }
 
 deserializeJSON = function(response) {
-  response <- gsub("\\xef\\xbb\\xbf", "", response, useBytes = T) # strip BOM characters that are in the json data
+  #response <- gsub("\\xef\\xbb\\xbf", "", response, useBytes = T) # strip BOM characters that are in the json data
   return(jsonlite::fromJSON(response, simplifyVector=FALSE, simplifyDataFrame=FALSE, simplifyMatrix=FALSE))
 }
 


### PR DESCRIPTION
The PIC-SURE API has been updated to return properly formatted data and strip the BOM away ahead of time.