### PR TITLE
ALS-11934: document automatic inclusion of filter variables

### DIFF
--- a/R/clauses.R
+++ b/R/clauses.R
@@ -20,9 +20,10 @@
 #' @return An opaque Clause handle.
 #'
 #' @details
-#' To include concept paths in query output without filtering, pass them to
-#' [`buildQuery()`][picsure::buildQuery]'s `includeConcepts` argument — output
-#' columns are no longer a clause type.
+#' Variables you filter on are returned as output columns automatically. To
+#' include *additional* concept paths in query output without filtering, pass
+#' them to [`buildQuery()`][picsure::buildQuery]'s `includeConcepts` argument —
+#' output columns are not a clause type.
 #' @examples
 #' \dontrun{
 #' sex <- picsure::buildClause(
@@ -97,8 +98,10 @@ buildClauseGroup <- function(clauses, operator = "AND") {
 #'   [`buildClause()`][picsure::buildClause] /
 #'   [`buildClauseGroup()`][picsure::buildClauseGroup]) to filter on, or `NULL`
 #'   for an include-only query.
-#' @param includeConcepts Optional character vector of concept paths to include
-#'   as output columns. Order is preserved and duplicates are dropped.
+#' @param includeConcepts Optional character vector of *additional* concept
+#'   paths to include as output columns, beyond the variables already named in
+#'   `phenotypicFilter` (those are returned automatically). Order is preserved
+#'   and duplicates are dropped.
 #' @return An opaque Query handle.
 #' @examples
 #' \dontrun{

--- a/man/buildClause.Rd
+++ b/man/buildClause.Rd
@@ -34,9 +34,10 @@ query with [`buildQuery()`][picsure::buildQuery], or running via
 [`runQuery()`][picsure::runQuery].
 }
 \details{
-To include concept paths in query output without filtering, pass them to
-[`buildQuery()`][picsure::buildQuery]'s `includeConcepts` argument — output
-columns are no longer a clause type.
+Variables you filter on are returned as output columns automatically. To
+include *additional* concept paths in query output without filtering, pass
+them to [`buildQuery()`][picsure::buildQuery]'s `includeConcepts` argument —
+output columns are not a clause type.
 }
 \examples{
 \dontrun{

--- a/man/buildQuery.Rd
+++ b/man/buildQuery.Rd
@@ -12,8 +12,10 @@ buildQuery(phenotypicFilter = NULL, includeConcepts = NULL)
 [`buildClauseGroup()`][picsure::buildClauseGroup]) to filter on, or `NULL`
 for an include-only query.}
 
-\item{includeConcepts}{Optional character vector of concept paths to include
-as output columns. Order is preserved and duplicates are dropped.}
+\item{includeConcepts}{Optional character vector of *additional* concept
+paths to include as output columns, beyond the variables already named in
+`phenotypicFilter` (those are returned automatically). Order is preserved
+and duplicates are dropped.}
 }
 \value{
 An opaque Query handle.


### PR DESCRIPTION
## Summary

Companion to [pic-sure-python-adapter-hpds#24](https://github.com/hms-dbmi/pic-sure-python-adapter-hpds/pull/24) for [ALS-11934](https://hms-dbmi.atlassian.net/browse/ALS-11934).

The Python adapter now returns variables referenced in a query's filter clauses as output columns automatically, without repeating them in `includeConcepts`. This refreshes the R `buildClause` / `buildQuery` roxygen docstrings to match and regenerates `man/`.

## Notes
- **No wrapper code change.** The reticulate wrappers forward `phenotypicFilter` / `includeConcepts` to the Python adapter 1:1, so the new behavior propagates automatically; only the docs needed updating.
- Targets `query_v3` (the v3 integration branch), matching where the rest of the v3 R work lives.

## Test plan
- `devtools::test()`: 444 passed, 0 failures
- `roxygen2::roxygenise()`: regenerated `man/buildClause.Rd`, `man/buildQuery.Rd` cleanly